### PR TITLE
Added the ordinalIndicators component

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -44,7 +44,7 @@
     "eqnull"        : false,     // true: Tolerate use of `== null`
     "esversion"     : 6,         // {int} Specify the ECMAScript version to which the code must adhere.
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
-                                 // (ex: `for each`, multiple try/catch, function expression…)
+                                 // (ex: `for each`, multiple try/catch, function expressionï¿½)
     "evil"          : true,     // true: Tolerate use of `eval` and `new Function()`
     "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
     "funcscope"     : false,     // true: Tolerate defining variables inside control statements
@@ -88,18 +88,20 @@
 
     // Custom Globals
     "globals"       : { // additional predefined global variables
-		"T4Utils" : true ,
-		"importPackage" : true , 
-		"com" : true , 
-		"content" : true , 
-		"language" : true , 
-		"MediaManager" : true ,
-		"MediaUtils" : true ,
-		"dbStatement" : true , 
-		"section" : true , 
-		"publishCache" : true ,
-		"isPreview" : true,
-		"MessageDigest" : true,
-		"PathBuilder" : true		
-	}        
+        "T4Utils" : true ,
+        "importPackage" : true ,
+        "com" : true ,
+        "content" : true ,
+        "language" : true ,
+        "MediaManager" : true ,
+        "MediaUtils" : true ,
+        "dbStatement" : true ,
+        "section" : true ,
+        "publishCache" : true ,
+        "isPreview" : true,
+        "MessageDigest" : true,
+        "PathBuilder" : true,
+        "ContentHierarchy" : true,
+        "ContentManager" : true
+	}
 }

--- a/T4Utils/T4Utils.7.4.js
+++ b/T4Utils/T4Utils.7.4.js
@@ -4,7 +4,7 @@
  * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
  * @author Ben Margevicius
  * Copyright 2016. MIT licensed.
- * Built: Thu Apr 14 2016 14:55:28 GMT-0400 (Eastern Daylight Time).
+ * Built: Fri Apr 15 2016 12:11:23 GMT-0400 (EDT).
  */
 /**
  * Java dependencies - 
@@ -608,4 +608,162 @@ T4Utils.security.toSHA256 = function(plainText) {
 		document.write(e);
 	}
 	return hash;
+};
+/**
+* T4Utils.ordinalIndicators
+* @version v0.0.1
+* @link git+https://github.com/virginiacommonwealthuniversity/T4Utils.git
+* @author Joel Eisner
+* @date April 15, 2016
+* Copyright 2016. MIT licensed.
+*/
+/* jshint strict: false */
+
+/**
+* Ordinal indicators namespace declaration
+*/
+T4Utils.ordinalIndicators = T4Utils.ordinalIndicators || {};
+
+/**
+* Find the position of the content in context of the page
+* @return {hash} A hash with three key/value pairs: first, last, index
+* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind on the page
+* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind on the page
+* @return[2] {int} Returns a number, starting from zero, indicating the position of the content type on the page in relation to all other instances of that content type
+*/
+T4Utils.ordinalIndicators.page = function() {
+    // Define the initial states of all returned values
+    var pageFirst = false,
+        pageLast = false,
+        contentIndex, hash;
+    // Create function to delete excess array objects if they have identical keys...
+    function unique(arr) {
+        var comparer = function compareObject(a, b) {
+            if (a.key === b.key) {
+                return 0;
+            } else {
+                if (a.key < b.key) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        };
+        arr.sort(comparer);
+        for (var i = 0; i < arr.length - 1; ++i) {
+            if (comparer(arr[i], arr[i+1]) === 0) {
+                arr.splice(i, 1);
+            }
+        }
+        return arr;
+    }
+    // Grab all pieces of content on the page
+    var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent (com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent (section.getContent (publishCache.getChannel (), com.terminalfour.sitemanager.cache.CachedContent.APPROVED)));
+    // Run through each piece of content, find out all the content types, and create a key array...
+    var listContentTypeIDs = [];
+    var c;
+    for (c in cL) {
+        if (cL.hasOwnProperty(c)) {
+            var ctIDo = c.getTemplateID();
+            listContentTypeIDs.push({
+                'key': ctIDo,
+                'pieces': []
+            });
+        }
+    }
+    unique(listContentTypeIDs);
+    // Run through each piece of content, and put them in their corresponding key object
+    var n;
+    for (n in cL) {
+        if (cL.hasOwnProperty(n)) {
+            var ctIDt = n.getTemplateID(),
+                uID = n.getID(),
+                k;
+            for (k in listContentTypeIDs) {
+                if (ctIDt === k.key) {
+                    var p = k.pieces;
+                    p.push(uID);
+                }
+            }
+        }
+    }
+    // Get the current content type ID and unique ID
+    var this_ctID = content.getTemplateID(),
+        this_uID = content.getID();
+    // Set the pageFirst and pageLast values
+    var z;
+    for (z in listContentTypeIDs) {
+        // Find the current content piece in the array of all alike content on the page...
+        if (z.key === this_ctID) {
+            var pieces = z.pieces,
+                pFirst = pieces[0],
+                pLength = pieces.length,
+                pIndex = pLength - 1,
+                pLast = pieces[pIndex];
+            // Set the contentIndex variable...
+            for (var i = 0; i < pLength; i++) {
+                var piece = pieces[i];
+                if (this_uID === piece) {
+                    contentIndex = i;
+                    break;
+                }
+            }
+            // If this piece of content is the first of its kind on the page...
+            if (pFirst === this_uID) {
+                pageFirst = true;
+            } else {
+                pageFirst = false;
+            }
+            // If this piece of content is the last of its kind on the page...
+            if (pLast === this_uID) {
+                pageLast = true;
+            } else {
+                pageLast = false;
+            }
+        }
+    }
+    hash = {
+        first: pageFirst,
+        last: pageLast,
+        index: contentIndex
+    };
+    return hash;
+};
+
+/**
+* Find the position of the content in context within a groupset
+* @return {hash} A hash with two key/value pairs: first, last
+* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind in a groupset
+* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind in a groupset
+*/
+T4Utils.ordinalIndicators.group = function() {
+    var tid = content.getTemplateID(),
+        sid = section.getID(),
+        oCH = new ContentHierarchy(),
+        oCM = ContentManager.getManager(),
+        contentInSection = oCH.getContent(dbStatement,sid,'en'),
+        groupFirst, groupLast, hash;
+    for (var i = 0; i < contentInSection.length; i++) {
+        if (content.getID() === oCM.get(dbStatement,contentInSection[i],"en").getID()) {
+            if (i === 0) {
+                groupFirst = true;
+            } else if (tid !==  oCM.get(dbStatement,contentInSection[i-1],"en").getTemplateID()) {
+                groupFirst = true;
+            } else {
+                groupFirst = false;
+            }
+            if (i === contentInSection.length-1) {
+                groupLast = true;
+            } else if (tid !==  oCM.get(dbStatement,contentInSection[i+1],"en").getTemplateID()) {
+                groupLast = true;
+            } else {
+                groupLast = false;
+            }
+        }
+    }
+    hash = {
+        first: groupFirst,
+        last: groupLast
+    };
+    return hash;
 };

--- a/T4Utils/T4Utils.7.4.js
+++ b/T4Utils/T4Utils.7.4.js
@@ -4,22 +4,30 @@
  * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
  * @author Ben Margevicius
  * Copyright 2016. MIT licensed.
- * Built: Fri Apr 15 2016 12:11:23 GMT-0400 (EDT).
+ * Built: Tue Apr 19 2016 10:28:49 GMT-0400 (EDT).
  */
 /**
- * Java dependencies - 
- * @version v1.0.2
+ * Java dependencies -
+ * @version v1.0.3
  * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
  * @author Ben Margevicius
  * @date April 14, 2016
  * Copyright 2016. MIT licensed.
  */
 /* jshint strict: false */
+/* Java Language */
+importPackage(java.lang);
 /* getSectionInfo.js */
-importClass(com.terminalfour.publish.PathBuilder); 
+importClass(com.terminalfour.publish.PathBuilder);
 /* media.js */
 importPackage(com.terminalfour.media);
 importPackage(com.terminalfour.media.utils);
+/* ordinalIndicators.js */
+importClass(com.terminalfour.sitemanager.cache.utils.CSHelper);
+importClass(com.terminalfour.sitemanager.cache.CachedContent);
+importPackage(com.terminalfour.sitemanager);
+importPackage(com.terminalfour.content);
+
 /*  Versioning    
 	6/24/2015 - Initial
 	6/30/2015 - Added stuff from T4's javascript util (https://community.terminalfour.com/forum/index.php?topic=426.0)
@@ -611,7 +619,7 @@ T4Utils.security.toSHA256 = function(plainText) {
 };
 /**
 * T4Utils.ordinalIndicators
-* @version v0.0.1
+* @version v1.0.0
 * @link git+https://github.com/virginiacommonwealthuniversity/T4Utils.git
 * @author Joel Eisner
 * @date April 15, 2016
@@ -625,17 +633,11 @@ T4Utils.security.toSHA256 = function(plainText) {
 T4Utils.ordinalIndicators = T4Utils.ordinalIndicators || {};
 
 /**
-* Find the position of the content in context of the page
-* @return {hash} A hash with three key/value pairs: first, last, index
-* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind on the page
-* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind on the page
-* @return[2] {int} Returns a number, starting from zero, indicating the position of the content type on the page in relation to all other instances of that content type
+* Find if the position of the content within the page is the first of its kind
+* @return {bool} true if first, false if not
 */
-T4Utils.ordinalIndicators.page = function() {
-    // Define the initial states of all returned values
-    var pageFirst = false,
-        pageLast = false,
-        contentIndex, hash;
+T4Utils.ordinalIndicators.pageFirst = (function() {
+    var pageFirst = false;
     // Create function to delete excess array objects if they have identical keys...
     function unique(arr) {
         var comparer = function compareObject(a, b) {
@@ -650,6 +652,7 @@ T4Utils.ordinalIndicators.page = function() {
             }
         };
         arr.sort(comparer);
+        var end;
         for (var i = 0; i < arr.length - 1; ++i) {
             if (comparer(arr[i], arr[i+1]) === 0) {
                 arr.splice(i, 1);
@@ -661,29 +664,25 @@ T4Utils.ordinalIndicators.page = function() {
     var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent (com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent (section.getContent (publishCache.getChannel (), com.terminalfour.sitemanager.cache.CachedContent.APPROVED)));
     // Run through each piece of content, find out all the content types, and create a key array...
     var listContentTypeIDs = [];
-    var c;
-    for (c in cL) {
-        if (cL.hasOwnProperty(c)) {
-            var ctIDo = c.getTemplateID();
-            listContentTypeIDs.push({
-                'key': ctIDo,
-                'pieces': []
-            });
-        }
+    for (var j = 0; j < cL.length; j++) {
+        var contentPiece = cL[j],
+            pieceID = contentPiece.getTemplateID();
+        listContentTypeIDs.push({
+            'key': pieceID,
+            'pieces': []
+        });
     }
     unique(listContentTypeIDs);
     // Run through each piece of content, and put them in their corresponding key object
-    var n;
-    for (n in cL) {
-        if (cL.hasOwnProperty(n)) {
-            var ctIDt = n.getTemplateID(),
-                uID = n.getID(),
-                k;
-            for (k in listContentTypeIDs) {
-                if (ctIDt === k.key) {
-                    var p = k.pieces;
-                    p.push(uID);
-                }
+    for (var k = 0; k < cL.length; k++) {
+        var cP = cL[k],
+            ctID = cP.getTemplateID(),
+            uID = cP.getID();
+        for (var l = 0; l < listContentTypeIDs.length; l++) {
+            var contentTypeID = listContentTypeIDs[l];
+            if (ctID === contentTypeID.key) {
+                var p = contentTypeID.pieces;
+                p.push(uID);
             }
         }
     }
@@ -691,29 +690,89 @@ T4Utils.ordinalIndicators.page = function() {
     var this_ctID = content.getTemplateID(),
         this_uID = content.getID();
     // Set the pageFirst and pageLast values
-    var z;
-    for (z in listContentTypeIDs) {
+    for (var m = 0; m < listContentTypeIDs.length; m++) {
+        var typeID = listContentTypeIDs[m];
         // Find the current content piece in the array of all alike content on the page...
-        if (z.key === this_ctID) {
-            var pieces = z.pieces,
-                pFirst = pieces[0],
-                pLength = pieces.length,
-                pIndex = pLength - 1,
-                pLast = pieces[pIndex];
-            // Set the contentIndex variable...
-            for (var i = 0; i < pLength; i++) {
-                var piece = pieces[i];
-                if (this_uID === piece) {
-                    contentIndex = i;
-                    break;
-                }
-            }
+        if (typeID.key === this_ctID) {
+            var pieces = typeID.pieces,
+            pFirst = pieces[0];
             // If this piece of content is the first of its kind on the page...
             if (pFirst === this_uID) {
                 pageFirst = true;
             } else {
                 pageFirst = false;
             }
+        }
+    }
+    return pageFirst;
+})();
+
+/**
+* Find if the position of the content within the page is the last of its kind
+* @return {bool} true if last, false if not
+*/
+T4Utils.ordinalIndicators.pageLast = (function() {
+    var pageLast = false;
+    // Create function to delete excess array objects if they have identical keys...
+    function unique(arr) {
+        var comparer = function compareObject(a, b) {
+            if (a.key === b.key) {
+                return 0;
+            } else {
+                if (a.key < b.key) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        };
+        arr.sort(comparer);
+        var end;
+        for (var i = 0; i < arr.length - 1; ++i) {
+            if (comparer(arr[i], arr[i+1]) === 0) {
+                arr.splice(i, 1);
+            }
+        }
+        return arr;
+    }
+    // Grab all pieces of content on the page
+    var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent (com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent (section.getContent (publishCache.getChannel (), com.terminalfour.sitemanager.cache.CachedContent.APPROVED)));
+    // Run through each piece of content, find out all the content types, and create a key array...
+    var listContentTypeIDs = [];
+    for (var j = 0; j < cL.length; j++) {
+        var contentPiece = cL[j],
+            pieceID = contentPiece.getTemplateID();
+        listContentTypeIDs.push({
+            'key': pieceID,
+            'pieces': []
+        });
+    }
+    unique(listContentTypeIDs);
+    // Run through each piece of content, and put them in their corresponding key object
+    for (var k = 0; k < cL.length; k++) {
+        var cP = cL[k],
+            ctID = cP.getTemplateID(),
+            uID = cP.getID();
+        for (var l = 0; l < listContentTypeIDs.length; l++) {
+            var contentTypeID = listContentTypeIDs[l];
+            if (ctID === contentTypeID.key) {
+                var p = contentTypeID.pieces;
+                p.push(uID);
+            }
+        }
+    }
+    // Get the current content type ID and unique ID
+    var this_ctID = content.getTemplateID(),
+        this_uID = content.getID();
+    // Set the pageFirst and pageLast values
+    for (var m = 0; m < listContentTypeIDs.length; m++) {
+        var typeID = listContentTypeIDs[m];
+        // Find the current content piece in the array of all alike content on the page...
+        if (typeID.key === this_ctID) {
+            var pieces = typeID.pieces,
+            pLength = pieces.length,
+            pIndex = pLength - 1,
+            pLast = pieces[pIndex];
             // If this piece of content is the last of its kind on the page...
             if (pLast === this_uID) {
                 pageLast = true;
@@ -722,27 +781,97 @@ T4Utils.ordinalIndicators.page = function() {
             }
         }
     }
-    hash = {
-        first: pageFirst,
-        last: pageLast,
-        index: contentIndex
-    };
-    return hash;
-};
+    return pageLast;
+})();
 
 /**
-* Find the position of the content in context within a groupset
-* @return {hash} A hash with two key/value pairs: first, last
-* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind in a groupset
-* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind in a groupset
+* Find index of the content within the page
+* @return {int} the content's index number (starting from 0)
 */
-T4Utils.ordinalIndicators.group = function() {
+T4Utils.ordinalIndicators.pageIndex = (function() {
+    var contentIndex;
+    // Create function to delete excess array objects if they have identical keys...
+    function unique(arr) {
+        var comparer = function compareObject(a, b) {
+            if (a.key === b.key) {
+                return 0;
+            } else {
+                if (a.key < b.key) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        };
+        arr.sort(comparer);
+        var end;
+        for (var i = 0; i < arr.length - 1; ++i) {
+            if (comparer(arr[i], arr[i+1]) === 0) {
+                arr.splice(i, 1);
+            }
+        }
+        return arr;
+    }
+    // Grab all pieces of content on the page
+    var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent (com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent (section.getContent (publishCache.getChannel (), com.terminalfour.sitemanager.cache.CachedContent.APPROVED)));
+    // Run through each piece of content, find out all the content types, and create a key array...
+    var listContentTypeIDs = [];
+    for (var j = 0; j < cL.length; j++) {
+        var contentPiece = cL[j],
+            pieceID = contentPiece.getTemplateID();
+        listContentTypeIDs.push({
+            'key': pieceID,
+            'pieces': []
+        });
+    }
+    unique(listContentTypeIDs);
+    // Run through each piece of content, and put them in their corresponding key object
+    for (var k = 0; k < cL.length; k++) {
+        var cP = cL[k],
+            ctID = cP.getTemplateID(),
+            uID = cP.getID();
+        for (var l = 0; l < listContentTypeIDs.length; l++) {
+            var contentTypeID = listContentTypeIDs[l];
+            if (ctID === contentTypeID.key) {
+                var p = contentTypeID.pieces;
+                p.push(uID);
+            }
+        }
+    }
+    // Get the current content type ID and unique ID
+    var this_ctID = content.getTemplateID(),
+        this_uID = content.getID();
+    // Set the pageFirst and pageLast values
+    for (var m = 0; m < listContentTypeIDs.length; m++) {
+        var typeID = listContentTypeIDs[m];
+        // Find the current content piece in the array of all alike content on the page...
+        if (typeID.key === this_ctID) {
+            var pieces = typeID.pieces,
+            pLength = pieces.length;
+            // Set the contentIndex variable...
+            for (var n = 0; n < pLength; n++) {
+                var piece = pieces[n];
+                if (this_uID === piece) {
+                    contentIndex = n;
+                    break;
+                }
+            }
+        }
+    }
+    return contentIndex;
+})();
+
+/**
+* Find if the position of the content within a groupset is the first of its kind
+* @return {bool} true if first, false if not
+*/
+T4Utils.ordinalIndicators.groupFirst = (function() {
     var tid = content.getTemplateID(),
         sid = section.getID(),
         oCH = new ContentHierarchy(),
         oCM = ContentManager.getManager(),
         contentInSection = oCH.getContent(dbStatement,sid,'en'),
-        groupFirst, groupLast, hash;
+        groupFirst = false;
     for (var i = 0; i < contentInSection.length; i++) {
         if (content.getID() === oCM.get(dbStatement,contentInSection[i],"en").getID()) {
             if (i === 0) {
@@ -752,6 +881,24 @@ T4Utils.ordinalIndicators.group = function() {
             } else {
                 groupFirst = false;
             }
+        }
+    }
+    return groupFirst;
+})();
+
+/**
+* Find if the position of the content within a groupset is the last of its kind
+* @return {bool} true if last, false if not
+*/
+T4Utils.ordinalIndicators.groupLast = (function() {
+    var tid = content.getTemplateID(),
+        sid = section.getID(),
+        oCH = new ContentHierarchy(),
+        oCM = ContentManager.getManager(),
+        contentInSection = oCH.getContent(dbStatement,sid,'en'),
+        groupLast = false;
+    for (var i = 0; i < contentInSection.length; i++) {
+        if (content.getID() === oCM.get(dbStatement,contentInSection[i],"en").getID()) {
             if (i === contentInSection.length-1) {
                 groupLast = true;
             } else if (tid !==  oCM.get(dbStatement,contentInSection[i+1],"en").getTemplateID()) {
@@ -761,9 +908,5 @@ T4Utils.ordinalIndicators.group = function() {
             }
         }
     }
-    hash = {
-        first: groupFirst,
-        last: groupLast
-    };
-    return hash;
-};
+    return groupLast;
+})();

--- a/components/javadependencies.js
+++ b/components/javadependencies.js
@@ -1,14 +1,21 @@
 /**
- * Java dependencies - 
- * @version v1.0.2
+ * Java dependencies -
+ * @version v1.0.3
  * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
  * @author Ben Margevicius
  * @date April 14, 2016
  * Copyright 2016. MIT licensed.
  */
 /* jshint strict: false */
+/* Java Language */
+importPackage(java.lang);
 /* getSectionInfo.js */
-importClass(com.terminalfour.publish.PathBuilder); 
+importClass(com.terminalfour.publish.PathBuilder);
 /* media.js */
 importPackage(com.terminalfour.media);
 importPackage(com.terminalfour.media.utils);
+/* ordinalIndicators.js */
+importClass(com.terminalfour.sitemanager.cache.utils.CSHelper);
+importClass(com.terminalfour.sitemanager.cache.CachedContent);
+importPackage(com.terminalfour.sitemanager);
+importPackage(com.terminalfour.content);

--- a/components/ordinalIndicators.js
+++ b/components/ordinalIndicators.js
@@ -1,0 +1,158 @@
+/**
+* T4Utils.ordinalIndicators
+* @version v0.0.1
+* @link git+https://github.com/virginiacommonwealthuniversity/T4Utils.git
+* @author Joel Eisner
+* @date April 15, 2016
+* Copyright 2016. MIT licensed.
+*/
+/* jshint strict: false */
+
+/**
+* Ordinal indicators namespace declaration
+*/
+T4Utils.ordinalIndicators = T4Utils.ordinalIndicators || {};
+
+/**
+* Find the position of the content in context of the page
+* @return {hash} A hash with three key/value pairs: first, last, index
+* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind on the page
+* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind on the page
+* @return[2] {int} Returns a number, starting from zero, indicating the position of the content type on the page in relation to all other instances of that content type
+*/
+T4Utils.ordinalIndicators.page = function() {
+    // Define the initial states of all returned values
+    var pageFirst = false,
+        pageLast = false,
+        contentIndex, hash;
+    // Create function to delete excess array objects if they have identical keys...
+    function unique(arr) {
+        var comparer = function compareObject(a, b) {
+            if (a.key === b.key) {
+                return 0;
+            } else {
+                if (a.key < b.key) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        };
+        arr.sort(comparer);
+        for (var i = 0; i < arr.length - 1; ++i) {
+            if (comparer(arr[i], arr[i+1]) === 0) {
+                arr.splice(i, 1);
+            }
+        }
+        return arr;
+    }
+    // Grab all pieces of content on the page
+    var cL = com.terminalfour.sitemanager.cache.utils.CSHelper.extractCachedContent (com.terminalfour.sitemanager.cache.utils.CSHelper.removeSpecialContent (section.getContent (publishCache.getChannel (), com.terminalfour.sitemanager.cache.CachedContent.APPROVED)));
+    // Run through each piece of content, find out all the content types, and create a key array...
+    var listContentTypeIDs = [];
+    var c;
+    for (c in cL) {
+        if (cL.hasOwnProperty(c)) {
+            var ctIDo = c.getTemplateID();
+            listContentTypeIDs.push({
+                'key': ctIDo,
+                'pieces': []
+            });
+        }
+    }
+    unique(listContentTypeIDs);
+    // Run through each piece of content, and put them in their corresponding key object
+    var n;
+    for (n in cL) {
+        if (cL.hasOwnProperty(n)) {
+            var ctIDt = n.getTemplateID(),
+                uID = n.getID(),
+                k;
+            for (k in listContentTypeIDs) {
+                if (ctIDt === k.key) {
+                    var p = k.pieces;
+                    p.push(uID);
+                }
+            }
+        }
+    }
+    // Get the current content type ID and unique ID
+    var this_ctID = content.getTemplateID(),
+        this_uID = content.getID();
+    // Set the pageFirst and pageLast values
+    var z;
+    for (z in listContentTypeIDs) {
+        // Find the current content piece in the array of all alike content on the page...
+        if (z.key === this_ctID) {
+            var pieces = z.pieces,
+                pFirst = pieces[0],
+                pLength = pieces.length,
+                pIndex = pLength - 1,
+                pLast = pieces[pIndex];
+            // Set the contentIndex variable...
+            for (var i = 0; i < pLength; i++) {
+                var piece = pieces[i];
+                if (this_uID === piece) {
+                    contentIndex = i;
+                    break;
+                }
+            }
+            // If this piece of content is the first of its kind on the page...
+            if (pFirst === this_uID) {
+                pageFirst = true;
+            } else {
+                pageFirst = false;
+            }
+            // If this piece of content is the last of its kind on the page...
+            if (pLast === this_uID) {
+                pageLast = true;
+            } else {
+                pageLast = false;
+            }
+        }
+    }
+    hash = {
+        first: pageFirst,
+        last: pageLast,
+        index: contentIndex
+    };
+    return hash;
+};
+
+/**
+* Find the position of the content in context within a groupset
+* @return {hash} A hash with two key/value pairs: first, last
+* @return[0] {bool} Returns true/false in relation to if the content is the first of its kind in a groupset
+* @return[1] {bool} Returns true/false in relation to if the content is the last of its kind in a groupset
+*/
+T4Utils.ordinalIndicators.group = function() {
+    var tid = content.getTemplateID(),
+        sid = section.getID(),
+        oCH = new ContentHierarchy(),
+        oCM = ContentManager.getManager(),
+        contentInSection = oCH.getContent(dbStatement,sid,'en'),
+        groupFirst, groupLast, hash;
+    for (var i = 0; i < contentInSection.length; i++) {
+        if (content.getID() === oCM.get(dbStatement,contentInSection[i],"en").getID()) {
+            if (i === 0) {
+                groupFirst = true;
+            } else if (tid !==  oCM.get(dbStatement,contentInSection[i-1],"en").getTemplateID()) {
+                groupFirst = true;
+            } else {
+                groupFirst = false;
+            }
+            if (i === contentInSection.length-1) {
+                groupLast = true;
+            } else if (tid !==  oCM.get(dbStatement,contentInSection[i+1],"en").getTemplateID()) {
+                groupLast = true;
+            } else {
+                groupLast = false;
+            }
+        }
+    }
+    hash = {
+        first: groupFirst,
+        last: groupLast
+    };
+    return hash;
+};

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -1,0 +1,25 @@
+module.exports = {
+    t4version: '7.4', //you'll have to config this for your environment
+    components: ['./components/javadependencies.js',
+                './components/base.js',
+                './components/sitemanager.js',
+                './components/brokerUtils.js',
+                './components/elementInfo.js',
+                './components/getSectionInfo.js',
+                './components/media.js',
+                './components/security.js',
+                './components/ordinalIndicators.js'
+    ],
+    outputDir: './T4Utils/',
+    isProduction: (process.env.NODE_ENV === 'production'), //Set from command line like SET NODE_ENV=production.
+    banner: ['/**',
+            ' * <%= package.name %> - <%= package.description %>',
+            ' * @version v<%= package.version %>',
+            ' * @link <%= package.repository.url %>',
+            ' * @author <%= package.author %>',
+            ' * Copyright ' + new Date().getFullYear() + '. <%= package.license %> licensed.',
+            ' * Built: ' + new Date() + '.',
+            ' */',
+            ''
+    ].join('\n')
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,9 @@
-/** 	
+/**
 * t4utils - This is a utility class that can be used in conjuntion with content types in the Terminal 4 CMS.
 * @version v1.0.2
 * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
 * @author Ben Margevicius
-* Copyright 2016. MIT licensed. 
+* Copyright 2016. MIT licensed.
 */
 
 var gulp = require('gulp'),
@@ -15,36 +15,12 @@ var gulp = require('gulp'),
 	header = require('gulp-header'),
 	package = require('./package.json'),
 	jsdoc = require('gulp-jsdoc3'),
-	jshint = require('gulp-jshint'),	
-	jshintStylish = require('jshint-stylish');
-	
-
-var config = {	
-	t4version: '7.4', //you'll have to config this for your environment
-	components: ['./components/javadependencies.js',
-				 './components/base.js', 				 
-				 './components/sitemanager.js',
-				 './components/brokerUtils.js',
-				 './components/elementInfo.js',
-				 './components/getSectionInfo.js',
-				 './components/media.js',
-				 './components/security.js'
-				],		
-	outputDir: './T4Utils/',
-	isProduction: (process.env.NODE_ENV === 'production'), //Set from command line like SET NODE_ENV=production. 
-	banner: ['/**',
-		' * <%= package.name %> - <%= package.description %>',
-		' * @version v<%= package.version %>',
-		' * @link <%= package.repository.url %>',		
-		' * @author <%= package.author %>',		
-		' * Copyright ' + new Date().getFullYear() + '. <%= package.license %> licensed.',	
-		' * Built: ' + new Date() + '.',		
-		' */',
-		''].join('\n')
-};
+	jshint = require('gulp-jshint'),
+	jshintStylish = require('jshint-stylish'),
+    config = require('./gulpconfig.js');
 
 gulp.task('clean', function () {
-	return del(config.outputDir + '**/*.js');	
+	return del(config.outputDir + '**/*.js');
 });
 
 gulp.task('doc', function(cb) {
@@ -55,14 +31,14 @@ gulp.task('doc', function(cb) {
 gulp.task('build-utils', ['clean'], function() {
 	return gulp.src(config.components)
 		.pipe(jshint()) 	//check our js
-		.pipe(jshint.reporter(jshintStylish, {verbose: true})) //report in pretty colors	
+		.pipe(jshint.reporter(jshintStylish, {verbose: true})) //report in pretty colors
 		.pipe(jshint.reporter('fail'))
-		.pipe(concat('T4Utils.' + config.t4version + '.js'))		
+		.pipe(concat('T4Utils.' + config.t4version + '.js'))
 		.pipe(gulpif(config.isProduction, uglify()))
 		.pipe(gulpif(config.isProduction, rename({ suffix: ".min" })))
-		.pipe(header(config.banner, { package: package })) //add our commented headers. 		
+		.pipe(header(config.banner, { package: package })) //add our commented headers.
 		.pipe(gulp.dest(config.outputDir));
 });
 
 
-gulp.task('default', ['clean','build-utils']);	
+gulp.task('default', ['clean','build-utils']);


### PR DESCRIPTION
Hey, Ben:

So I've gone ahead and extended the T4Utils.js library with what we've been calling ordinal indicators. What it does, is it allows us (within a piece of content) to tell where the content exists in context within a group or on the page. Here's what the ordinalIndicators component has to offer:
- T4Utils.ordinalIndicators.pageFirst = Returns true if the piece of content is the first of its kind on the page, otherwise false.
- T4Utils.ordinalIndicators.pageLast = Returns true if the piece of content is the last of its kind on the page, otherwise false.
- T4Utils.ordinalIndicators.pageIndex = Returns a number that represents the index of where the content exists on the page in relation to its content type. This number starts at 0.
- T4Utils.ordinalIndicators.groupFirst = Returns true if the piece of content is the first in a group of the same content type, otherwise false.
- T4Utils.ordinalIndicators.groupLast = Returns true if the piece of content is the last in a group of the same content type, otherwise false.

If you'd like a little more insight on the differences between what we're calling page/group, check out go.vcu.edu/t4vcuutilsjs and there's an image with a pretty in depth diagram.

Let me know what you think!
- Joel Eisner
