### PR TITLE
T4Utils.brokerUtils.processT4Tag(...) Fix (Issue #10)

### DIFF
--- a/components/brokerUtils.js
+++ b/components/brokerUtils.js
@@ -1,22 +1,23 @@
 /**
- * T4Utils.brokerUtils - Broker Utils namespace for T4
- * @version v1.0.0
- * @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
- * @author Ben Margevicius
- * @date April 4, 2016
- * Copyright 2016. MIT licensed.
- */
+* T4Utils.brokerUtils - Broker Utils namespace for T4
+* @version v1.0.0
+* @link git+https://github.com/FPBSchoolOfNursing/T4Utils.git
+* @author Ben Margevicius
+* @date April 4, 2016
+* Copyright 2016. MIT licensed.
+*/
 /* jshint strict: false */
 /**
 * Security namespace declaration
 */
 T4Utils.brokerUtils = T4Utils.brokerUtils || {};
+
 /**
-*	Processes a t4 tag.
-*	@param {string} t4Tag - HTML style T4 tag that needs to be processed. Typically something from the media library.
-*	@return {string} A string value of the t4 tag output. Depends on the formatters you put in. 
+* Processes a t4 tag.
+* @param {string} t4Tag - HTML style T4 tag that needs to be processed. Typically something from the media library.
+* @return {string} A string value of the t4 tag output. Depends on the formatters you put in.
 */
 T4Utils.brokerUtils.processT4Tag = function (t4Tag) {
-	var myContent = content || null; 
-	return com.terminalfour.publish.utils.BrokerUtils.processT4Tags(dbStatement, publishCache, section, myContent, language, isPreview, t4Tag); 
+    var context = (typeof content !== 'undefined') ? content : null;
+    return com.terminalfour.publish.utils.BrokerUtils.processT4Tags(dbStatement, publishCache, section, context, language, isPreview, t4Tag);
 };

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -11,7 +11,7 @@ module.exports = {
                 './components/ordinalIndicators.js'
     ],
     outputDir: './T4Utils/',
-    isProduction: (process.env.NODE_ENV === 'production'), //Set from command line like SET NODE_ENV=production.
+    isProduction: (process.env.NODE_ENV === 'production'), //Set from command line like SET NODE_ENV=production (EXPORT NODE_ENV=production on MAC).
     banner: ['/**',
             ' * <%= package.name %> - <%= package.description %>',
             ' * @version v<%= package.version %>',


### PR DESCRIPTION
We've updated the processT4Tag() function in the brokerUtils module to work within content as well as page layouts. The way you had it before would switch between content or null, but it wasn't checking to see if the variable "content" existed or not, erroring out page layouts.

Hope this helps out! Also, sorry that this isn't an automatic-merge pull request 😓
